### PR TITLE
Update camera distance position

### DIFF
--- a/code/Player/UnicycleCamera.cs
+++ b/code/Player/UnicycleCamera.cs
@@ -46,6 +46,7 @@ internal class UnicycleCamera
 		var tr = Trace.Ray( center, targetPos )
 			.Ignore( pawn )
 			.Radius( 8 )
+			.WithoutTags("player")
 			.Run();
 
 		var endpos = tr.EndPosition;


### PR DESCRIPTION
Change trace inside UnicycleCamera to ignore entities with "player" tag.

It is anoying when playing with someone and you spawn in the same checkpoint, camera arm collides with another player model and you can't comfortably see where your pawn is.