### PR TITLE
Use sphere traces for movement / grounded check

### DIFF
--- a/Assets/Prefabs/UF_PLAYER.prefab
+++ b/Assets/Prefabs/UF_PLAYER.prefab
@@ -86,7 +86,39 @@
             "FallSound": "sounds/unicycle/unicycle.crash.default.sound",
             "JumpSound": "sounds/unicycle/unicycle.jump.sound",
             "PedalSound": "sounds/unicycle/unicycle.pedal.sound",
-            "PerfectPedalSound": "sounds/unicycle/unicycle.pedal.perfect.sound"
+            "PerfectPedalSound": "sounds/unicycle/unicycle.pedal.perfect.sound",
+            "SpeedGizmoGradient": {
+              "color": [
+                {
+                  "c": "0,0,0,1"
+                },
+                {
+                  "t": 0.25641027,
+                  "c": "1,0,0,1"
+                },
+                {
+                  "t": 0.52136755,
+                  "c": "1,0.75349,0.01395,1"
+                },
+                {
+                  "t": 0.767094,
+                  "c": "1,1,1,1"
+                },
+                {
+                  "t": 1,
+                  "c": "0,0.3,1,1"
+                }
+              ],
+              "alpha": [
+                {
+                  "a": 1
+                },
+                {
+                  "t": 1,
+                  "a": 1
+                }
+              ]
+            }
           },
           {
             "__type": "PlayerAnimator",

--- a/code/Player/UnicycleUnstuck.cs
+++ b/code/Player/UnicycleUnstuck.cs
@@ -9,7 +9,7 @@ internal class UnicycleUnstuck : Component
 	{
 		var mins = (Controller as UnicycleController).Mins;
 		var maxs = (Controller as UnicycleController).Maxs;
-		var result = Controller.TraceBBox( Controller.Position, Controller.Position, mins, maxs );
+		var result = Controller.TraceTire( Controller.Position, Controller.Position );
 
 		// Not stuck, we cool
 		if ( !result.StartedSolid )
@@ -30,7 +30,7 @@ internal class UnicycleUnstuck : Component
 				pos = Controller.Position + Vector3.Up * 5;
 			}
 
-			result = Controller.TraceBBox( pos, pos, mins, maxs );
+			result = Controller.TraceTire( pos, pos );
 
 			if ( !result.StartedSolid )
 			{


### PR DESCRIPTION
* Use sphere with radius of tyre for all traces in UnicycleController
* If grounded, keep tyre at floor height
* Add move history gizmos, showing path and ground normal
* Mouse over move history to see velocity and ground trace endpoints

![image](https://github.com/Facepunch/sbox-unicycle-frenzy/assets/1110904/99ffa04c-80fe-4508-9760-6e359214d29f)

Fixes #64 